### PR TITLE
fix-Bash syntax error in riscv-compliace test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,7 @@ tests-sw: riscv-compliance
 	make -C riscv-compliance
 
 riscv-compliance:
-	if [ "$(test_v)" == "1" ]; then \
+	if [ "$(test_v)" = "1" ]; then \
 		if [ ! -d riscv-compliance ]; then \
 			git clone -b v1.0 git://github.com/riscv/riscv-compliance.git; \
 		fi; \


### PR DESCRIPTION
The bash shell used to switch between riscv-compliace test version 1/2
is problematic. When `test_v` variable is set to 1, the master branch of
riscv-compliance is cloned instead of branch v1.0. This is a common bash
shell syntax error as explained in this stackoverflow thread.
(https://stackoverflow.com/questions/2011160/unexpected-operator-error)