### PR TITLE
Canonicalize cross compilation setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-ifndef CROSS_COMPILER
-export CROSS_COMPILER = riscv64-unknown-elf-
+ifndef CROSS_COMPILE
+export CROSS_COMPILE = riscv64-unknown-elf-
 endif
 
 dirs        = $(dir $(wildcard sw/[^_]*/))

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Notes: change the default ISA to 20191213, refer to [RISC-V GNU toolchain bumpin
 
 The default tools uses riscv64-unknown-elf-. If you would like to use others toolchains, you can define an environment to override it. For example,
 
-    export CROSS_COMPILER=riscv-none-elf-
+    export CROSS_COMPILE=riscv-none-elf-
 
 Therefore, you can use [The xPack GNU RISC-V Embedded GCC](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack) instead of building a toolchain yourself.
 

--- a/sw/common/Makefile.common
+++ b/sw/common/Makefile.common
@@ -1,15 +1,15 @@
 rv32c   ?= 0
 
-ifndef CROSS_COMPILER
-export CROSS_COMPILER = riscv64-unknown-elf-
+ifndef CROSS_COMPILE
+export CROSS_COMPILE = riscv64-unknown-elf-
 endif
 
-CC      := $(CROSS_COMPILER)gcc
-AS      := $(CROSS_COMPILER)as
-AR      := $(CROSS_COMPILER)ar
-OBJDUMP := $(CROSS_COMPILER)objdump
-OBJCOPY := $(CROSS_COMPILER)objcopy
-READELF := $(CROSS_COMPILER)readelf
+CC      := $(CROSS_COMPILE)gcc
+AS      := $(CROSS_COMPILE)as
+AR      := $(CROSS_COMPILE)ar
+OBJDUMP := $(CROSS_COMPILE)objdump
+OBJCOPY := $(CROSS_COMPILE)objcopy
+READELF := $(CROSS_COMPILE)readelf
 
 ifeq ($(rv32c), 1)
 ARCH    := -march=rv32imac_zicsr -mabi=ilp32

--- a/sw/coremark/riscv/core_portme.mak
+++ b/sw/coremark/riscv/core_portme.mak
@@ -53,7 +53,7 @@ PORT_SRCS = $(PORT_DIR)/core_portme.c
 
 #For native compilation and execution
 LOAD = echo Loading done
-RUN = $(CROSS_COMPILER)run
+RUN = $(CROSS_COMPILE)run
 
 OEXT = .o
 EXE = .elf

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,8 +3,8 @@ memsize    ?= 128
 test_v     ?= 2
 rv32c      ?= 0
 
-ifndef CROSS_COMPILER
-export CROSS_COMPILER = riscv64-unknown-elf-
+ifndef CROSS_COMPILE
+export CROSS_COMPILE = riscv64-unknown-elf-
 endif
 
 ifneq (, $(findstring darwin, $(shell gcc -dumpmachine)))
@@ -19,7 +19,7 @@ tests: riscv-arch-test
 	export ROOT_SRV32=$(ROOT_SRV32); \
 	export TARGET_SIM="$(ROOT_SRV32)/sim/sim +trace"; \
 	export TARGET_SWSIM="$(ROOT_SRV32)/tools/rvsim --memsize $(memsize)"; \
-	export RISCV_PREFIX=$(CROSS_COMPILER); \
+	export RISCV_PREFIX=$(CROSS_COMPILE); \
 	export RISCV_TARGET=srv32; \
 	$(MAKE) rv32c=$(rv32c) -C riscv-arch-test.v$(test_v)
 
@@ -27,7 +27,7 @@ tests-sw: riscv-arch-test
 	export ROOT_SRV32=$(ROOT_SRV32); \
 	export TARGET_SIM="$(ROOT_SRV32)/tools/rvsim --memsize $(memsize) -l trace.log"; \
 	export TARGET_SWSIM="$(ROOT_SRV32)/tools/rvsim --memsize $(memsize)"; \
-	export RISCV_PREFIX=$(CROSS_COMPILER); \
+	export RISCV_PREFIX=$(CROSS_COMPILE); \
 	export RISCV_TARGET=srv32; \
 	$(MAKE) rv32c=$(rv32c) -C riscv-arch-test.v$(test_v)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,14 +8,14 @@
     cd ${ROOT_SRV32}
     make build
 
-    export CROSS_COMPILER=riscv64-unknown-elf-
+    export CROSS_COMPILE=riscv64-unknown-elf-
     export TARGET_SIM=${ROOT_SRV32}/sim/sim
-    export RISCV_PREFIX=${CROSS_COMPILER}
+    export RISCV_PREFIX=${CROSS_COMPILE}
     export RISCV_TARGET=srv32
     make
 
     export TARGET_SIM=${ROOT_SRV32}/tools/rvsim
-    export RISCV_PREFIX=${CROSS_COMPILER}
+    export RISCV_PREFIX=${CROSS_COMPILE}
     export RISCV_TARGET=srv32
     make
 

--- a/tools/log2dis.pl
+++ b/tools/log2dis.pl
@@ -2,8 +2,8 @@
 use strict;
 
 my $VERBOSE = 1;
-my $CROSS_COMPILER = defined($ENV{'CROSS_COMPILER'}) ? $ENV{'CROSS_COMPILER'} : "riscv64-unknown-elf-";
-my $objdump = "${CROSS_COMPILER}objdump";
+my $CROSS_COMPILE = defined($ENV{'CROSS_COMPILE'}) ? $ENV{'CROSS_COMPILE'} : "riscv64-unknown-elf-";
+my $objdump = "${CROSS_COMPILE}objdump";
 my %DIS;
 $| = 1;
 


### PR DESCRIPTION
The use of environment variable "CROSS_COMPILE" is common. For example, the build systems for both Linux kernel and u-boot recognize the value specified by "CROSS_COMPILE" for target triples.

See https://www.kernel.org/doc/Documentation/kbuild/llvm.rst