### PR TITLE
Fix undefined pthread_ references on glibc < 2.34

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -53,7 +53,7 @@ else
 TRACELOG =
 endif
 
-LDFLAGS += -Lmini-gdbstub/build -lgdbstub
+LDFLAGS += -Lmini-gdbstub/build -lgdbstub -lpthread
 
 SRC      = rvsim.c decompress.c syscall.c elfloader.c getch.c htif.c \
            debug.c riscv-disas.c gdbstub.c map.c


### PR DESCRIPTION
## Summary
Building tools/rvsim with mini-gdbstub enabled can fail on systems with **glibc < 2.34** due to missing pthread symbols such as `pthread_create` / `pthread_join`.
Because `libgdbstub.a` uses pthread APIs, but rvsim’s link flags do not include pthread, causing the final link step to fail.
On **glibc >= 2.34**, this issue may not trigger a link error because [glibc merged libpthread functionality into libc](https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html)
## Change
Add pthread to the link flags in tools/Makefile:
```diff
- LDFLAGS += -Lmini-gdbstub/build -lgdbstub
+ LDFLAGS += -Lmini-gdbstub/build -lgdbstub -lpthread
```
## Note
This change is required on **glibc < 2.34** where pthread symbols are not provided by libc by default.
On glibc >= 2.34, `-lpthread` remains safe because glibc keeps the linker option working for backwards compatibility (empty libpthread.a is provided), so this should not affect newer systems.